### PR TITLE
uptime heartbeat

### DIFF
--- a/src/analytics.go
+++ b/src/analytics.go
@@ -105,6 +105,15 @@ type HeartbeatEvent struct {
 	Env       string    `json:"env"`
 }
 
+// DowntimeReportEvent event
+type DowntimeReportEvent struct {
+	EventType       string    `json:"eventType"`
+	Timestamp       time.Time `json:"timestamp"`
+	Cluster         string    `json:"cluster"`
+	DowntimeSeconds int       `json:"downtimeSeconds"`
+	Env             string    `json:"env"`
+}
+
 const (
 	// event name
 	reportIncident = "Report Incident"
@@ -112,6 +121,7 @@ const (
 	appStart       = "App Start"
 	latencyReport  = "Latency Report"
 	heartBeat      = "Heartbeat"
+	downtimeReport = "Downtime Report"
 )
 
 var client *insights.InsertClient
@@ -300,5 +310,16 @@ func AnalyticsHeartbeat(deviceID string) {
 		Timestamp: time.Now(),
 		Cluster:   deviceID,
 		Env:       env,
+	})
+}
+
+// AnalyticsDowntime reports downtime
+func AnalyticsDowntime(deviceID string, downtimeSeconds int) {
+	go sendToInsights(DowntimeReportEvent{
+		EventType:       downtimeReport,
+		Timestamp:       time.Now(),
+		Cluster:         deviceID,
+		Env:             env,
+		DowntimeSeconds: downtimeSeconds,
 	})
 }

--- a/src/heartbeat.go
+++ b/src/heartbeat.go
@@ -10,8 +10,6 @@ import (
 	"github.com/hashicorp/go-retryablehttp"
 )
 
-var heatbeatDuration = 60 * time.Second
-
 // StartHeartBeat starts heartbeat monitoring the program by OpsGenie
 func StartHeartBeat() {
 	genieURL := AssignString(GetConfig().OpsGenieConfig.HeartBeatURL, "https://api.opsgenie.com/v2/heartbeats/latency-monitor/ping")
@@ -20,6 +18,11 @@ func StartHeartBeat() {
 	if err != nil {
 		Alert(fmt.Sprintf("OpsGenie error %v", err))
 	}
+}
+
+// UptimeHeartBeat sends heartbeat to uptime counter
+func UptimeHeartBeat() {
+	AnalyticsHeartbeat(GetConfig().Name)
 }
 
 // HeartBeatToOpsGenie send heart beat to ops genie

--- a/src/main.go
+++ b/src/main.go
@@ -32,6 +32,7 @@ func main() {
 	RunInterval(PulsarFunctions, TimeDuration(cfg.PulsarPerfConfig.IntervalSeconds, 300, time.Second))
 	RunInterval(PulsarTenants, TimeDuration(cfg.PulsarOpsConfig.IntervalSeconds, 120, time.Second))
 	RunInterval(StartHeartBeat, TimeDuration(cfg.OpsGenieConfig.IntervalSeconds, 240, time.Second))
+	RunInterval(UptimeHeartBeat, 30*time.Second)
 	RunInterval(MeasureLatency, TimeDuration(cfg.PulsarPerfConfig.IntervalSeconds, 300, time.Second))
 	MonitorSites()
 	SingleTopicLatencyTestThread()

--- a/src/pulsar-admin.go
+++ b/src/pulsar-admin.go
@@ -68,7 +68,7 @@ func PulsarTenants() {
 		if err != nil {
 			errMsg := fmt.Sprintf("tenant-test failed on cluster %s error: %v", queryURL, err)
 			Alert(errMsg)
-			ReportIncident(cluster.Name, clusterName, "persisted cluster tenants test failure", errMsg, &cluster.AlertPolicy, false)
+			ReportIncident(cluster.Name, clusterName, "persisted cluster tenants test failure", errMsg, &cluster.AlertPolicy)
 		} else {
 			PromGaugeInt(TenantsGaugeOpt(), cluster.Name, tenantSize)
 			ClearIncident(cluster.Name)

--- a/src/pulsar-function.go
+++ b/src/pulsar-function.go
@@ -78,7 +78,7 @@ func PulsarFunctions() {
 		if err != nil {
 			errMsg := fmt.Sprintf("trigger-function failed on cluster %s error: %v", name, err)
 			Alert(errMsg)
-			ReportIncident(name, name, "persisted trigger-function failure", errMsg, &cluster.AlertPolicy, false)
+			ReportIncident(name, name, "persisted trigger-function failure", errMsg, &cluster.AlertPolicy)
 		} else {
 			ClearIncident(name)
 		}

--- a/src/website-monitor.go
+++ b/src/website-monitor.go
@@ -50,7 +50,7 @@ func mon(site SiteCfg) {
 		errMsg := fmt.Sprintf("site monitoring %s error: %v", site.URL, err)
 		title := fmt.Sprintf("persisted kafkaesque.io %s endpoint failure", site.Name)
 		Alert(errMsg)
-		ReportIncident(site.Name, site.Name, title, errMsg, &site.AlertPolicy, false)
+		ReportIncident(site.Name, site.Name, title, errMsg, &site.AlertPolicy)
 	}
 }
 

--- a/src/websocket.go
+++ b/src/websocket.go
@@ -177,7 +177,7 @@ func TestWsLatency(config WsConfig) {
 		errMsg := fmt.Sprintf("cluster %s, %s test message latency %v over the budget %v",
 			config.Cluster, config.Name, result.Latency, expectedLatency)
 		Alert(errMsg)
-		ReportIncident(config.Name, config.Cluster, "persisted latency test failure", errMsg, &config.AlertPolicy, false)
+		ReportIncident(config.Name, config.Cluster, "persisted latency test failure", errMsg, &config.AlertPolicy)
 	} else {
 		log.Printf("websocket pubsub succeeded with latency %v expected latency %v on topic %s, cluster %s\n",
 			result.Latency, expectedLatency, config.TopicName, config.Cluster)


### PR DESCRIPTION
- Use a dedicated goroutine to track the uptime heartbeat
- Downtime calculation is now based on the very first successful message producing instead of the entire producing and consuming message path.