### PR TITLE
In-cluster kubernetes monitoring and Partition topic message latency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/pierrec/lz4 v2.4.1+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.4.0
+	github.com/prometheus/common v0.9.1
 	github.com/sirupsen/logrus v1.4.2
 	k8s.io/api v0.18.5
 	k8s.io/apimachinery v0.18.5

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,10 @@ github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrU
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4 h1:Hs82Z41s6SdL1CELW+XaDYmOH4hkBN4/N9og/AsOv7E=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/apache/pulsar-client-go v0.1.0 h1:2BFZztxtNgFyOzBc+5On84CX6aIZW5xwh7KM0MWigGI=
@@ -590,6 +592,7 @@ google.golang.org/grpc v1.21.0/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ij
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.23.1/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/src/analytics.go
+++ b/src/analytics.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/kafkaesque-io/pulsar-monitor/src/util"
 	insights "github.com/newrelic/go-insights/client"
 )
 
@@ -129,7 +130,7 @@ var env string
 
 // SetupAnalytics initializes and validates the configuration
 func SetupAnalytics() {
-	env = AssignString(os.Getenv("DeployEnv"), "testing")
+	env = util.AssignString(os.Getenv("DeployEnv"), "testing")
 	if GetConfig().AnalyticsConfig.InsightsWriteKey == "" || GetConfig().AnalyticsConfig.InsightsAccountID == "" {
 		return
 	}

--- a/src/cluster-monitor.go
+++ b/src/cluster-monitor.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/kafkaesque-io/pulsar-monitor/src/k8s"
+)
+
+// K8s pulsar cluster monitor
+
+// ClusterHealth a cluster health struct
+type ClusterHealth struct {
+	sync.RWMutex
+	Status k8s.ClusterStatus
+}
+
+// Get gets the cluster health status
+func (h *ClusterHealth) Get() k8s.ClusterStatus {
+	h.RLock()
+	h.RUnlock()
+	return h.Status
+}
+
+// Set sets the cluster health status
+func (h *ClusterHealth) Set(status k8s.ClusterStatus) {
+	h.Lock()
+	h.Status = status
+	h.Unlock()
+}
+
+// EvaluateClusterHealth evaluates and reports the k8s cluster health
+func EvaluateClusterHealth(client *k8s.Client) error {
+	cfg := GetConfig().K8sConfig
+	cluster := GetConfig().Name // again this is for in-cluster monitoring only
+
+	if err := client.UpdateReplicas(); err != nil {
+		return err
+	}
+	if err := client.WatchPods(k8s.DefaultPulsarNamespace); err != nil {
+		return err
+	}
+	desc, status := client.EvalHealth()
+	clusterHealth.Set(status)
+	if status != k8s.OK {
+		errMsg := fmt.Sprintf("cluster %s, k8s pulsar cluster status is unhealthy, error message %s", cluster, desc)
+		Alert(errMsg)
+		if status == k8s.TotalDown {
+			ReportIncident(cluster, cluster, "persisted latency test failure", errMsg, &cfg.AlertPolicy)
+		}
+	}
+	log.Printf("k8 cluster status %d", status)
+	return nil
+}
+
+// MonitorK8sPulsarCluster start K8sPulsarClusterMonitor thread
+func MonitorK8sPulsarCluster() error {
+	cfg := GetConfig().K8sConfig
+	if !cfg.Enabled {
+		return nil
+	}
+
+	clientset, err := k8s.GetK8sClient()
+	if err != nil {
+		log.Printf("failed to get k8s clientset %v or get pods under pulsar namespace", err)
+		return err
+	}
+
+	go func(client *k8s.Client) {
+		log.Println("start k8s cluster monitoring ...")
+		ticker := time.NewTicker(10 * time.Second)
+		for {
+			select {
+			case <-ticker.C:
+				if err := EvaluateClusterHealth(clientset); err != nil {
+					log.Printf("k8s monitoring failed to watchpods error: %v", err)
+				}
+			}
+		}
+
+	}(clientset)
+	return nil
+}

--- a/src/config.go
+++ b/src/config.go
@@ -104,11 +104,20 @@ type WsConfig struct {
 	AlertPolicy     AlertPolicyCfg `json:"AlertPolicy"`
 }
 
+// K8sClusterCfg is configuration to monitor kubernete cluster
+// only to be enabled in-cluster monitoring
+type K8sClusterCfg struct {
+	Enabled       bool           `json:"enabled"`
+	KubeConfigDir string         `json:"kubeConfigDir"`
+	AlertPolicy   AlertPolicyCfg `json:"AlertPolicy"`
+}
+
 // Configuration - this server's configuration
 type Configuration struct {
 	Name              string             `json:"name"`
 	Token             string             `json:"token"`
 	TrustStore        string             `json:"trustStore"`
+	K8sConfig         K8sClusterCfg      `json:"k8sConfig"`
 	AnalyticsConfig   AnalyticsCfg       `json:"analyticsConfig"`
 	PrometheusConfig  PrometheusCfg      `json:"prometheusConfig"`
 	SlackConfig       SlackCfg           `json:"slackConfig"`

--- a/src/config.go
+++ b/src/config.go
@@ -73,18 +73,19 @@ type PulsarAdminRESTCfg struct {
 
 // TopicCfg is topic configuration
 type TopicCfg struct {
-	Name            string         `json:"name"`
-	Token           string         `json:"token"`
-	TrustStore      string         `json:"trustStore"`
-	LatencyBudgetMs int            `json:"latencyBudgetMs"`
-	PulsarURL       string         `json:"pulsarUrl"`
-	TopicName       string         `json:"topicName"`
-	OutputTopic     string         `json:"outputTopic"`
-	IntervalSeconds int            `json:"intervalSeconds"`
-	ExpectedMsg     string         `json:"expectedMsg"`
-	PayloadSizes    []string       `json:"payloadSizes"`
-	NumOfMessages   int            `json:"numberOfMessages"`
-	AlertPolicy     AlertPolicyCfg `json:"AlertPolicy"`
+	Name               string         `json:"name"`
+	Token              string         `json:"token"`
+	TrustStore         string         `json:"trustStore"`
+	NumberOfPartitions int            `json:"numberOfPartitions"`
+	LatencyBudgetMs    int            `json:"latencyBudgetMs"`
+	PulsarURL          string         `json:"pulsarUrl"`
+	TopicName          string         `json:"topicName"`
+	OutputTopic        string         `json:"outputTopic"`
+	IntervalSeconds    int            `json:"intervalSeconds"`
+	ExpectedMsg        string         `json:"expectedMsg"`
+	PayloadSizes       []string       `json:"payloadSizes"`
+	NumOfMessages      int            `json:"numberOfMessages"`
+	AlertPolicy        AlertPolicyCfg `json:"AlertPolicy"`
 }
 
 // WsConfig is configuration to monitor WebSocket pub sub latency

--- a/src/heartbeat.go
+++ b/src/heartbeat.go
@@ -8,11 +8,12 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
+	"github.com/kafkaesque-io/pulsar-monitor/src/util"
 )
 
 // StartHeartBeat starts heartbeat monitoring the program by OpsGenie
 func StartHeartBeat() {
-	genieURL := AssignString(GetConfig().OpsGenieConfig.HeartBeatURL, "https://api.opsgenie.com/v2/heartbeats/latency-monitor/ping")
+	genieURL := util.AssignString(GetConfig().OpsGenieConfig.HeartBeatURL, "https://api.opsgenie.com/v2/heartbeats/latency-monitor/ping")
 	genieKey := GetConfig().OpsGenieConfig.HeartbeatKey
 	err := HeartBeatToOpsGenie(genieURL, genieKey)
 	if err != nil {

--- a/src/incident.go
+++ b/src/incident.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
+	"github.com/kafkaesque-io/pulsar-monitor/src/util"
 )
 
 // report incident which usually is high level of escalation and paging
@@ -104,7 +105,7 @@ func (t *IncidentAlertPolicy) clear() int {
 
 func newPolicy(component, msg, desc string, eval *AlertPolicyCfg) IncidentAlertPolicy {
 	newTracker := IncidentAlertPolicy{}
-	newTracker.EvalWindowSeconds = TimeDuration(eval.MovingWindowSeconds, 1, time.Second)
+	newTracker.EvalWindowSeconds = util.TimeDuration(eval.MovingWindowSeconds, 1, time.Second)
 	newTracker.Alerts = make(map[time.Time]bool)
 	newTracker.LimitInWindow = eval.CeilingInMovingWindow
 	newTracker.Limit = eval.Ceiling
@@ -143,7 +144,7 @@ func ClearIncident(component string) {
 // NewIncident creates a Incident object
 func NewIncident(component, alias, msg, desc, priority string) Incident {
 	p := "P2" //default priority
-	if StrContains(AllowedPriorities, priority) {
+	if util.StrContains(AllowedPriorities, priority) {
 		p = priority
 	}
 	return Incident{

--- a/src/incident_test.go
+++ b/src/incident_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/kafkaesque-io/pulsar-monitor/src/util"
 )
 
 func TestUnmarshConfigFile(t *testing.T) {
@@ -115,7 +117,7 @@ func TestGenMultipleDefaultPayloadSize(t *testing.T) {
 
 func TestIncidentAlertPolicy(t *testing.T) {
 
-	assert(t, StrContains([]string{"test", "foo"}, "foo"), "fail to eval container string")
+	assert(t, util.StrContains([]string{"test", "foo"}, "foo"), "fail to eval container string")
 
 	policy := AlertPolicyCfg{
 		Ceiling:               20,

--- a/src/main.go
+++ b/src/main.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/google/gops/agent"
+	"github.com/kafkaesque-io/pulsar-monitor/src/util"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -23,7 +24,7 @@ var clusterHealth = ClusterHealth{}
 func main() {
 	// runtime.GOMAXPROCS does not the container's CPU quota in Kubernetes
 	// therefore, it requires to be set explicitly
-	runtime.GOMAXPROCS(StrToInt(os.Getenv("GOMAXPROCS"), 1))
+	runtime.GOMAXPROCS(util.StrToInt(os.Getenv("GOMAXPROCS"), 1))
 
 	// gops debug instrument
 	if err := agent.Listen(agent.Options{}); err != nil {
@@ -31,7 +32,7 @@ func main() {
 	}
 
 	flag.Parse()
-	effectiveCfgFile := AssignString(os.Getenv("PULSAR_OPS_MONITOR_CFG"), *cfgFile)
+	effectiveCfgFile := util.AssignString(os.Getenv("PULSAR_OPS_MONITOR_CFG"), *cfgFile)
 	log.Println("config file ", effectiveCfgFile)
 	ReadConfigFile(effectiveCfgFile)
 
@@ -40,10 +41,10 @@ func main() {
 
 	SetupAnalytics()
 
-	AnalyticsAppStart(AssignString(cfg.Name, "dev"))
+	AnalyticsAppStart(util.AssignString(cfg.Name, "dev"))
 	MonitorK8sPulsarCluster()
-	RunInterval(PulsarTenants, TimeDuration(cfg.PulsarAdminConfig.IntervalSeconds, 120, time.Second))
-	RunInterval(StartHeartBeat, TimeDuration(cfg.OpsGenieConfig.IntervalSeconds, 240, time.Second))
+	RunInterval(PulsarTenants, util.TimeDuration(cfg.PulsarAdminConfig.IntervalSeconds, 120, time.Second))
+	RunInterval(StartHeartBeat, util.TimeDuration(cfg.OpsGenieConfig.IntervalSeconds, 240, time.Second))
 	RunInterval(UptimeHeartBeat, 30*time.Second) // fixed 30 seconds for heartbeat
 	MonitorSites()
 	TopicLatencyTestThread()
@@ -53,7 +54,7 @@ func main() {
 	if cfg.PrometheusConfig.ExposeMetrics {
 		log.Printf("start to listen to http port %s", cfg.PrometheusConfig.Port)
 		http.Handle("/metrics", promhttp.Handler())
-		http.ListenAndServe(AssignString(cfg.PrometheusConfig.Port, ":8089"), nil)
+		http.ListenAndServe(util.AssignString(cfg.PrometheusConfig.Port, ":8089"), nil)
 	}
 	for {
 		select {

--- a/src/main.go
+++ b/src/main.go
@@ -18,6 +18,8 @@ var (
 
 type complete struct{} //emptry struct as a single for channel
 
+var clusterHealth = ClusterHealth{}
+
 func main() {
 	// runtime.GOMAXPROCS does not the container's CPU quota in Kubernetes
 	// therefore, it requires to be set explicitly
@@ -39,6 +41,7 @@ func main() {
 	SetupAnalytics()
 
 	AnalyticsAppStart(AssignString(cfg.Name, "dev"))
+	MonitorK8sPulsarCluster()
 	RunInterval(PulsarTenants, TimeDuration(cfg.PulsarAdminConfig.IntervalSeconds, 120, time.Second))
 	RunInterval(StartHeartBeat, TimeDuration(cfg.OpsGenieConfig.IntervalSeconds, 240, time.Second))
 	RunInterval(UptimeHeartBeat, 30*time.Second) // fixed 30 seconds for heartbeat

--- a/src/payload.go
+++ b/src/payload.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/kafkaesque-io/pulsar-monitor/src/util"
 )
 
 // manage the payload size of Pulsar message
@@ -33,7 +35,7 @@ func (p *Payload) GenDefaultPayload() []byte {
 func (p Payload) createPayload() []byte {
 	size := randRange(p.Ceiling, p.Floor)
 	//use random to make compress impossible
-	return RandStringBytes(size)
+	return util.RandStringBytes(size)
 }
 
 // PrefixPayload creates string prefix in the payload

--- a/src/pulsar-admin.go
+++ b/src/pulsar-admin.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
+	"github.com/kafkaesque-io/pulsar-monitor/src/util"
 )
 
 // PulsarAdminTenant probes the tenant endpoint to get a list of tenants
@@ -55,7 +56,7 @@ func PulsarAdminTenant(clusterURL, token string) (int, error) {
 // PulsarTenants get a list of tenants on each cluster
 func PulsarTenants() {
 	clusters := GetConfig().PulsarAdminConfig.Clusters
-	token := AssignString(GetConfig().PulsarAdminConfig.Token, GetConfig().Token)
+	token := util.AssignString(GetConfig().PulsarAdminConfig.Token, GetConfig().Token)
 
 	for _, cluster := range clusters {
 		adminURL, err := url.ParseRequestURI(cluster.URL)
@@ -63,7 +64,7 @@ func PulsarTenants() {
 			panic(err) //panic because this is a showstopper
 		}
 		clusterName := adminURL.Hostname()
-		queryURL := SingleSlashJoin(cluster.URL, "/admin/v2/tenants")
+		queryURL := util.SingleSlashJoin(cluster.URL, "/admin/v2/tenants")
 		tenantSize, err := PulsarAdminTenant(queryURL, token)
 		if err != nil {
 			errMsg := fmt.Sprintf("tenant-test failed on cluster %s error: %v", queryURL, err)

--- a/src/pulsar-latency.go
+++ b/src/pulsar-latency.go
@@ -265,7 +265,7 @@ func TestTopicLatency(topicCfg TopicCfg) {
 		Alert(errMsg)
 		ReportIncident(clusterName, clusterName, "persisted latency test failure", errMsg, &topicCfg.AlertPolicy)
 	} else if stddev, mean, within3Sigma := stdVerdict.Push(float64(result.Latency.Milliseconds())); !within3Sigma {
-		errMsg := fmt.Sprintf("cluster %s, %s test message latency %v over two standard deviation %v ms and mean is %v ms",
+		errMsg := fmt.Sprintf("cluster %s, %s test message latency %v over three standard deviation %v ms and mean is %v ms",
 			clusterName, testName, result.Latency, stddev, mean)
 		AnalyticsLatencyReport(clusterName, testName, "", int(result.Latency.Milliseconds()), true, false)
 		Alert(errMsg)

--- a/src/pulsar-latency.go
+++ b/src/pulsar-latency.go
@@ -258,12 +258,13 @@ func TestTopicLatency(topicCfg TopicCfg) {
 		AnalyticsLatencyReport(clusterName, testName, "message delivery out of order", int(result.Latency.Milliseconds()), false, true)
 		Alert(errMsg)
 	} else if result.Latency > expectedLatency {
+		stdVerdict.Add(float64(result.Latency.Milliseconds()))
 		errMsg := fmt.Sprintf("cluster %s, %s test message latency %v over the budget %v",
 			clusterName, testName, result.Latency, expectedLatency)
 		AnalyticsLatencyReport(clusterName, testName, "", int(result.Latency.Milliseconds()), true, false)
 		Alert(errMsg)
 		ReportIncident(clusterName, clusterName, "persisted latency test failure", errMsg, &topicCfg.AlertPolicy)
-	} else if stddev, mean, within2Sigma := stdVerdict.Push(float64(result.Latency.Milliseconds())); !within2Sigma {
+	} else if stddev, mean, within3Sigma := stdVerdict.Push(float64(result.Latency.Milliseconds())); !within3Sigma {
 		errMsg := fmt.Sprintf("cluster %s, %s test message latency %v over two standard deviation %v ms and mean is %v ms",
 			clusterName, testName, result.Latency, stddev, mean)
 		AnalyticsLatencyReport(clusterName, testName, "", int(result.Latency.Milliseconds()), true, false)

--- a/src/pulsar-latency.go
+++ b/src/pulsar-latency.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/apache/pulsar-client-go/pulsar"
+	"github.com/kafkaesque-io/pulsar-monitor/src/topic"
+	"github.com/kafkaesque-io/pulsar-monitor/src/util"
 )
 
 const (
@@ -45,7 +47,7 @@ func PubSubLatency(clusterName, tokenStr, uri, topicName, outputTopic, msgPrefix
 		}
 
 		if strings.HasPrefix(uri, "pulsar+ssl://") {
-			trustStore := AssignString(GetConfig().TrustStore, "/etc/ssl/certs/ca-bundle.crt")
+			trustStore := util.AssignString(GetConfig().TrustStore, "/etc/ssl/certs/ca-bundle.crt")
 			if trustStore == "" {
 				panic("this is fatal that we are missing trustStore while pulsar+ssl is required")
 			}
@@ -85,7 +87,7 @@ func PubSubLatency(clusterName, tokenStr, uri, topicName, outputTopic, msgPrefix
 
 	// use the same input topic if outputTopic does not exist
 	// Two topic use case could be for Pulsar function test
-	consumerTopic := AssignString(outputTopic, topicName)
+	consumerTopic := util.AssignString(outputTopic, topicName)
 	consumer, err := client.Subscribe(pulsar.ConsumerOptions{
 		Topic:                       consumerTopic,
 		SubscriptionName:            subscriptionName,
@@ -115,7 +117,7 @@ func PubSubLatency(clusterName, tokenStr, uri, topicName, outputTopic, msgPrefix
 	//  and because no need to protect map iteration to calculate results
 	mapMutex := &sync.Mutex{}
 
-	receiveTimeout := TimeDuration(5+(maxPayloadSize/102400), 10, time.Second)
+	receiveTimeout := util.TimeDuration(5+(maxPayloadSize/102400), 10, time.Second)
 	go func() {
 
 		lastMessageIndex := -1 // to track the message delivery order
@@ -195,7 +197,7 @@ func PubSubLatency(clusterName, tokenStr, uri, topicName, outputTopic, msgPrefix
 	}
 
 	ticker := time.NewTicker(time.Duration(5*len(payloads)) * time.Second)
-	go ticker.Stop()
+	defer ticker.Stop()
 	select {
 	case receiverLatency := <-completeChan:
 		return receiverLatency, nil
@@ -215,7 +217,7 @@ func TopicLatencyTestThread() {
 	for _, topic := range topics {
 		log.Println(topic.Name)
 		go func(t TopicCfg) {
-			ticker := time.NewTicker(TimeDuration(t.IntervalSeconds, 60, time.Second))
+			ticker := time.NewTicker(util.TimeDuration(t.IntervalSeconds, 60, time.Second))
 			TestTopicLatency(t)
 			for {
 				select {
@@ -235,18 +237,25 @@ func TestTopicLatency(topicCfg TopicCfg) {
 		panic(err) //panic because this is a showstopper
 	}
 	clusterName := adminURL.Hostname()
+	token := util.AssignString(topicCfg.Token, GetConfig().Token)
 
-	stdVerdict := GetStdBucket(clusterName)
+	if topicCfg.NumberOfPartitions < 2 {
+		testTopicLatency(clusterName, token, topicCfg)
+	} else {
+		testPartitionTopic(clusterName, token, topicCfg)
+	}
+}
 
-	token := AssignString(topicCfg.Token, GetConfig().Token)
-	expectedLatency := TimeDuration(topicCfg.LatencyBudgetMs, latencyBudget, time.Millisecond)
+func testTopicLatency(clusterName, token string, topicCfg TopicCfg) {
+	stdVerdict := util.GetStdBucket(clusterName)
+	expectedLatency := util.TimeDuration(topicCfg.LatencyBudgetMs, latencyBudget, time.Millisecond)
 	prefix := "messageid"
 	payloads, maxPayloadSize := AllMsgPayloads(prefix, topicCfg.PayloadSizes, topicCfg.NumOfMessages)
 	log.Printf("send %d messages to topic %s on cluster %s with latency budget %v, %v, %d\n",
 		len(payloads), topicCfg.TopicName, topicCfg.PulsarURL, expectedLatency, topicCfg.PayloadSizes, topicCfg.NumOfMessages)
 	result, err := PubSubLatency(clusterName, token, topicCfg.PulsarURL, topicCfg.TopicName, topicCfg.OutputTopic, prefix, topicCfg.ExpectedMsg, payloads, maxPayloadSize)
 
-	testName := AssignString(topicCfg.Name, pubSubSubsystem)
+	testName := util.AssignString(topicCfg.Name, pubSubSubsystem)
 	log.Printf("cluster %s has message latency %v", clusterName, result.Latency)
 	if err != nil {
 		errMsg := fmt.Sprintf("cluster %s, %s latency test Pulsar error: %v", clusterName, testName, err)
@@ -284,4 +293,35 @@ func expectedMessage(payload, expected string) string {
 		return fmt.Sprintf("%s%s", payload, expected[1:len(expected)])
 	}
 	return payload
+}
+
+func testPartitionTopic(clusterName, token string, cfg TopicCfg) {
+	trustStore := util.AssignString(cfg.TrustStore, GetConfig().TrustStore, "/etc/ssl/certs/ca-bundle.crt")
+	adminRESTURL := ""
+	testName := "partition-topic-test"
+	//TODO: reconcile with numberofpartitions from k8s broker replicas
+	pt, err := topic.NewPartitionTopic(cfg.PulsarURL, token, trustStore, cfg.TopicName, adminRESTURL, cfg.NumberOfPartitions)
+	if err != nil {
+		log.Printf("failed to create PartitionTopic test object, error: %v", err)
+		return
+	}
+	log.Printf("partition-topic object %v\n", pt)
+	latency, err := pt.TestPartitionTopic()
+	if err != nil {
+		errMsg := fmt.Sprintf("cluster %s, %s latency test Pulsar error: %v", clusterName, testName, err)
+		Alert(errMsg)
+		// ReportIncident(clusterName, clusterName, "persisted latency test failure", errMsg, &topicCfg.AlertPolicy)
+		AnalyticsLatencyReport(clusterName, testName, err.Error(), -1, false, false)
+	}
+	log.Println("partition topic concluded...")
+	expectedLatency := util.TimeDuration(cfg.LatencyBudgetMs, latencyBudget, time.Millisecond)
+	if latency > expectedLatency {
+		errMsg := fmt.Sprintf("cluster %s, partition topic test message latency %v over the budget %v",
+			clusterName, latency, expectedLatency)
+		AnalyticsLatencyReport(clusterName, testName, errMsg, int(latency.Milliseconds()), true, false)
+		Alert(errMsg)
+		// ReportIncident(clusterName, clusterName, "persisted latency test failure", errMsg, &cfg.AlertPolicy)
+	} else {
+		log.Printf("%d partition topics test concluded with latency %v", pt.NumberOfPartitions, latency)
+	}
 }

--- a/src/stats/standard-dev.go
+++ b/src/stats/standard-dev.go
@@ -19,9 +19,9 @@ func NewStandardDeviation(name string) StandardDeviation {
 	}
 }
 
-// Push a float64 to calculate standard deviation and returns σ and whether the number is over 2σ in positive right side of bell curve
-// 2σ is at odd of every three weeks
-func (sd *StandardDeviation) Push(num float64) (std, mean float64, within2Sigma bool) {
+// Push a float64 to calculate standard deviation and returns σ and whether the number is over 3σ in positive right side of bell curve
+// 3σ is at odd of every three weeks
+func (sd *StandardDeviation) Push(num float64) (std, mean float64, within3Sigma bool) {
 	sd.Buckets = append(sd.Buckets, num)
 	sd.Sum += num
 	counter := len(sd.Buckets)
@@ -34,7 +34,12 @@ func (sd *StandardDeviation) Push(num float64) (std, mean float64, within2Sigma 
 	std = math.Sqrt(std / float64(counter))
 	sd.Std = std
 
-	// 2σ evaluation only applies to 10 more data samples
-	return std, sd.Mean, num-sd.Mean < 2*std || counter < 10
+	// 3σ evaluation only applies to 10 more data samples
+	return std, sd.Mean, num-sd.Mean < 3*std || counter < 10
 
+}
+
+// Add a float64 sample to the bucket
+func (sd *StandardDeviation) Add(num float64) {
+	sd.Buckets = append(sd.Buckets, num)
 }

--- a/src/topic/partition-topics.go
+++ b/src/topic/partition-topics.go
@@ -1,0 +1,217 @@
+package topic
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/apache/pulsar-client-go/pulsar"
+	"github.com/kafkaesque-io/pulsar-monitor/src/util"
+	"github.com/prometheus/common/log"
+	logrus "github.com/sirupsen/logrus"
+)
+
+// partition topics can be used to test availabilities of all PartitionTopic
+
+// PartitionTopics data struct is the persistent partition topic name and number of partitions it has
+type PartitionTopics struct {
+	NumberOfPartitions int
+	PulsarURL          string
+	Token              string
+	TrustStore         string
+	Tenant             string
+	Namespace          string
+	PartitionTopicName string
+	TopicFullname      string
+	BaseAdminURL       string
+	log                *logrus.Entry
+}
+
+// NewPartitionTopic creates a PartitionTopic test object
+func NewPartitionTopic(url, token, trustStore, topicFn, adminURL string, numOfPartitions int) (*PartitionTopics, error) {
+	isPersistent, tenant, ns, topic, err := util.TokenizeTopicFullName(topicFn)
+	if err != nil {
+		return nil, err
+	}
+	if !isPersistent {
+		return nil, fmt.Errorf("does not support non-persistent topic in partition topic test")
+	}
+	return &PartitionTopics{
+		NumberOfPartitions: numOfPartitions,
+		PulsarURL:          url,
+		Token:              token,
+		TrustStore:         trustStore,
+		Tenant:             tenant,
+		Namespace:          ns,
+		PartitionTopicName: topic,
+		TopicFullname:      topicFn,
+		BaseAdminURL:       adminURL,
+		log:                logrus.WithFields(logrus.Fields{"app": "partition topic test"}),
+	}, nil
+}
+
+// GetPartitionTopic gets the partition topic
+func (pt *PartitionTopics) GetPartitionTopic() (bool, error) {
+	url := pt.BaseAdminURL + "/admin/v2/peristent/" + pt.Tenant + "/" + pt.Namespace + "/partitioned"
+
+	request, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return false, nil
+	}
+
+	request.Header.Add("Authorization", "Bearer "+pt.Token)
+	client := &http.Client{}
+	response, err := client.Do(request)
+	if response != nil {
+		defer response.Body.Close()
+	}
+	if err != nil {
+		pt.log.Errorf("GET PartitionTopic %s error %v", url, err)
+		return false, err
+	}
+
+	if response.StatusCode != http.StatusOK {
+		pt.log.Errorf("GET PartitionTopic %s response status code %d", url, response.StatusCode)
+		return false, err
+	}
+
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		pt.log.Errorf("GET PartitionTopic %s read response body error %v", url, err)
+		return false, err
+	}
+	var partitionTopic []string
+	if err = json.Unmarshal(body, &partitionTopic); err != nil {
+		pt.log.Errorf("GET PartitionTopic %s unmarshal response body error %v", url, err)
+		return false, err
+	}
+	expectedTopic := "persistent://" + pt.Tenant + "/" + pt.Namespace + "/" + pt.PartitionTopicName
+	found := false
+	for _, v := range partitionTopic {
+		if expectedTopic == v {
+			found = true
+		}
+	}
+
+	return found, nil
+}
+
+// CreatePartitionTopic creates a partition topic
+func (pt *PartitionTopics) CreatePartitionTopic() error {
+	url := pt.BaseAdminURL + "/admin/v2/peristent/" + pt.Tenant + "/" + pt.Namespace + "/" + pt.PartitionTopicName
+
+	byteInt := []byte(strconv.Itoa(pt.NumberOfPartitions))
+	request, err := http.NewRequest(http.MethodPut, url, bytes.NewReader(byteInt))
+	if err != nil {
+		return nil
+	}
+
+	request.Header.Add("Authorization", "Bearer "+pt.Token)
+	client := &http.Client{}
+	response, err := client.Do(request)
+	if response != nil {
+		defer response.Body.Close()
+	}
+	if err != nil {
+		pt.log.Errorf("GET PartitionTopic %s error %v", url, err)
+		return err
+	}
+
+	if response.StatusCode != http.StatusOK {
+		pt.log.Errorf("GET PartitionTopic %s response status code %d", url, response.StatusCode)
+		return err
+	}
+
+	return nil
+}
+
+// TestPartitionTopic sends multiple messages and to be verified by multiple consumers
+func (pt *PartitionTopics) TestPartitionTopic() (time.Duration, error) {
+
+	// notify the main thread with the latency to complete the exit of all consumers
+	completeChan := make(chan *util.ConsumerResult, pt.NumberOfPartitions)
+
+	partitionTopicSuffix := "-partition-"
+
+	client, err := util.GetPulsarClient(pt.PulsarURL, pt.Token, pt.TrustStore)
+	if err != nil {
+		return 0, err
+	}
+	defer client.Close()
+
+	pt.log.Infof("create a topic producer %s", pt.TopicFullname)
+	// create a pulsar producer
+	producer, err := client.CreateProducer(pulsar.ProducerOptions{
+		Topic: pt.TopicFullname,
+	})
+	if err != nil {
+		return 0, err
+	}
+	defer producer.Close()
+
+	// prepare the message
+	message := fmt.Sprintf("partition topic test message %v", time.Now())
+
+	// start multiple consumers and listens to individual partition topics
+	for i := 0; i < pt.NumberOfPartitions; i++ {
+		topicName := pt.TopicFullname + partitionTopicSuffix + strconv.Itoa(i)
+		pt.log.Infof("subscribe to partition topic %s wait on message %s", topicName, message)
+		go util.VerifyMessageByPulsarConsumer(client, topicName, message, completeChan)
+	}
+
+	// producer sends multiple messages
+	start := time.Now()
+	for i := 0; i < pt.NumberOfPartitions; i++ {
+		ctx := context.Background()
+
+		// Create a different message to send asynchronously
+		msg := pulsar.ProducerMessage{
+			Payload: []byte(message),
+			Key:     "partitionkey" + strconv.Itoa(i),
+		}
+
+		// Attempt to send message asynchronously and handle the response
+		if _, err := producer.Send(ctx, &msg); err != nil {
+			log.Errorf("failed to send message over partition topic , error: %v", err)
+			errMsg := fmt.Sprintf("fail to instantiate Pulsar client: %v", err)
+			// report error and exit
+			completeChan <- &util.ConsumerResult{
+				Err: errors.New(errMsg),
+			}
+		}
+
+		log.Infof("successfully published message on topic %s ", pt.TopicFullname)
+	}
+
+	receivedCounter := 0
+	successfulCounter := 0
+	ticker := time.NewTicker(90 * time.Second)
+	defer ticker.Stop()
+	for receivedCounter < pt.NumberOfPartitions {
+		select {
+		case signal := <-completeChan:
+			receivedCounter++
+			log.Infof(" received counter %d", receivedCounter)
+			if signal.Err != nil {
+				log.Errorf("topic %s receive error: %v", pt.TopicFullname, signal.Err)
+			} else if signal.InOrderDelivery {
+				successfulCounter++
+				log.Infof("successfully received counter %d", successfulCounter)
+			} else {
+				log.Errorf("topic %s failed to receive expected messages", pt.TopicFullname)
+			}
+			if receivedCounter >= pt.NumberOfPartitions {
+				return time.Since(start), nil
+			}
+		case <-ticker.C:
+			return 0, fmt.Errorf("timed out to receive message %d out of %d partition topics", receivedCounter, pt.NumberOfPartitions)
+		}
+	}
+	return 0, nil
+}

--- a/src/util/pulsar.go
+++ b/src/util/pulsar.go
@@ -1,0 +1,91 @@
+package util
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/apache/pulsar-client-go/pulsar"
+)
+
+// ConsumerResult is Pulsar Consumer result for channel communication
+type ConsumerResult struct {
+	Err             error
+	InOrderDelivery bool
+	Latency         time.Duration
+	Timestamp       time.Time
+}
+
+// GetPulsarClient gets the pulsar client object
+// Note: the caller has to Close() the client object
+func GetPulsarClient(pulsarURL, tokenStr, trustStore string) (pulsar.Client, error) {
+	clientOpt := pulsar.ClientOptions{
+		URL:               pulsarURL,
+		OperationTimeout:  30 * time.Second,
+		ConnectionTimeout: 30 * time.Second,
+	}
+
+	if tokenStr != "" {
+		clientOpt.Authentication = pulsar.NewAuthenticationToken(tokenStr)
+	}
+
+	if strings.HasPrefix(pulsarURL, "pulsar+ssl://") {
+		// trustStore := util.AssignString(GetConfig().TrustStore, "/etc/ssl/certs/ca-bundle.crt")
+		if trustStore == "" {
+			return nil, fmt.Errorf("this is fatal that we are missing trustStore while pulsar+ssl is required")
+		}
+		clientOpt.TLSTrustCertsFilePath = trustStore
+	}
+
+	return pulsar.NewClient(clientOpt)
+}
+
+// VerifyMessageByPulsarConsumer instantiates a Pulsar consumer and verifies an expected message
+func VerifyMessageByPulsarConsumer(client pulsar.Client, topicName, expectedMessage string, completeChan chan *ConsumerResult) error {
+	topicParts := strings.Split(topicName, "/")
+	subscriptionName := "partition-sub" + topicParts[len(topicParts)-1]
+	consumer, err := client.Subscribe(pulsar.ConsumerOptions{
+		Topic:                       topicName,
+		SubscriptionName:            subscriptionName,
+		Type:                        pulsar.Exclusive,
+		SubscriptionInitialPosition: pulsar.SubscriptionPositionLatest,
+	})
+	if err != nil {
+		log.Printf("failed to created partition topic consumer, error: %v", err)
+		return err
+	}
+	defer consumer.Close()
+
+	receivedCount := 0
+	receiveTimeout := 30 * time.Second
+	start := time.Now()
+	for time.Since(start) < time.Minute {
+		cCtx, cancel := context.WithTimeout(context.Background(), receiveTimeout)
+		defer cancel()
+
+		log.Printf("%s wait to receive on message count %d", topicName, receivedCount)
+		receivedCount++
+		msg, err := consumer.Receive(cCtx)
+		if err != nil {
+			completeChan <- &ConsumerResult{
+				Err: fmt.Errorf("consumer Receive() error: %v", err),
+			}
+			break
+		}
+		consumer.Ack(msg)
+		log.Printf("received message %s and expected message %s", string(msg.Payload()), expectedMessage)
+		if expectedMessage == string(msg.Payload()) {
+			log.Printf("expected message received by %s", topicName)
+			completeChan <- &ConsumerResult{
+				InOrderDelivery: true,
+				Timestamp:       time.Now(),
+			}
+		}
+	}
+	completeChan <- &ConsumerResult{
+		Err: fmt.Errorf("consumer Receive() error: %v", err),
+	}
+	return nil
+}

--- a/src/util/pulsar.go
+++ b/src/util/pulsar.go
@@ -75,17 +75,15 @@ func VerifyMessageByPulsarConsumer(client pulsar.Client, topicName, expectedMess
 			break
 		}
 		consumer.Ack(msg)
-		log.Printf("received message %s and expected message %s", string(msg.Payload()), expectedMessage)
+		// log.Printf("received message %s and expected message %s", string(msg.Payload()), expectedMessage)
 		if expectedMessage == string(msg.Payload()) {
 			log.Printf("expected message received by %s", topicName)
 			completeChan <- &ConsumerResult{
 				InOrderDelivery: true,
 				Timestamp:       time.Now(),
 			}
+			return nil
 		}
-	}
-	completeChan <- &ConsumerResult{
-		Err: fmt.Errorf("consumer Receive() error: %v", err),
 	}
 	return nil
 }

--- a/src/util/util.go
+++ b/src/util/util.go
@@ -1,9 +1,10 @@
-package main
+package util
 
 import (
 	"bufio"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log"
 	"math/rand"
 	"net/http"
@@ -226,4 +227,26 @@ func GetStdBucket(key string) *stats.StandardDeviation {
 		return &std
 	}
 	return stdVerdict
+}
+
+// TokenizeTopicFullName tokenizes a topic full name into persistent, tenant, namespace, and topic name.
+func TokenizeTopicFullName(topicFn string) (isPersistent bool, tenant, namespace, topic string, err error) {
+	var topicRoute string
+	if strings.HasPrefix(topicFn, "persistent://") {
+		topicRoute = strings.Replace(topicFn, "persistent://", "", 1)
+		isPersistent = true
+	} else if strings.HasPrefix(topicFn, "non-persistent://") {
+		topicRoute = strings.Replace(topicFn, "non-persistent://", "", 1)
+	} else {
+		return false, "", "", "", fmt.Errorf("invalid persistent or non-persistent part")
+	}
+
+	parts := strings.Split(topicRoute, "/")
+	if len(parts) == 3 {
+		return isPersistent, parts[0], parts[1], parts[2], nil
+	} else if len(parts) == 2 {
+		return isPersistent, parts[0], parts[1], "", nil
+	} else {
+		return false, "", "", "", fmt.Errorf("missing tenant, namespace, or topic name")
+	}
 }

--- a/src/website-monitor.go
+++ b/src/website-monitor.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
+	"github.com/kafkaesque-io/pulsar-monitor/src/util"
 )
 
 func monitorSite(site SiteCfg) error {
@@ -62,7 +63,7 @@ func MonitorSites() {
 	for _, site := range sites {
 		log.Println(site.URL)
 		go func(s SiteCfg) {
-			interval := TimeDuration(s.IntervalSeconds, 120, time.Second)
+			interval := util.TimeDuration(s.IntervalSeconds, 120, time.Second)
 			ticker := time.NewTicker(interval)
 			mon(s)
 			for {

--- a/src/websocket.go
+++ b/src/websocket.go
@@ -173,18 +173,19 @@ func TestWsLatency(config WsConfig) {
 
 	result, err := WsLatencyTest(config.ProducerURL, config.ConsumerURL, token)
 	if err != nil {
-		errMsg := fmt.Sprintf("cluster %s, %s latency test Pulsar error: %v", config.Cluster, config.Name, err)
+		errMsg := fmt.Sprintf("cluster %s, %s websocket latency test Pulsar error: %v", config.Cluster, config.Name, err)
 		Alert(errMsg)
 	} else if result.Latency > expectedLatency {
-		errMsg := fmt.Sprintf("cluster %s, %s test message latency %v over the budget %v",
+		stdVerdict.Add(float64(result.Latency.Milliseconds()))
+		errMsg := fmt.Sprintf("cluster %s, %s websocket test message latency %v over the budget %v",
 			config.Cluster, config.Name, result.Latency, expectedLatency)
 		Alert(errMsg)
-		ReportIncident(config.Name, config.Cluster, "persisted latency test failure", errMsg, &config.AlertPolicy)
-	} else if stddev, mean, within2Sigma := stdVerdict.Push(float64(result.Latency.Milliseconds())); !within2Sigma {
+		ReportIncident(config.Name, config.Cluster, "websocket persisted latency test failure", errMsg, &config.AlertPolicy)
+	} else if stddev, mean, within3Sigma := stdVerdict.Push(float64(result.Latency.Milliseconds())); !within3Sigma {
 		errMsg := fmt.Sprintf("cluster %s, websocket test message latency %v over two standard deviation %v ms and mean is %v ms",
 			config.Cluster, result.Latency, stddev, mean)
 		Alert(errMsg)
-		ReportIncident(config.Name, config.Cluster, "persisted latency test failure", errMsg, &config.AlertPolicy)
+		ReportIncident(config.Name, config.Cluster, "websocket persisted latency test failure", errMsg, &config.AlertPolicy)
 
 	} else {
 		log.Printf("websocket pubsub succeeded with latency %v expected latency %v on topic %s, cluster %s\n",

--- a/src/websocket.go
+++ b/src/websocket.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/kafkaesque-io/pulsar-monitor/src/util"
 )
 
 // PulsarMessage is the required message format for Pulsar Websocket message
@@ -166,10 +167,10 @@ func WsLatencyTest(producerURL, subscriptionURL, token string) (MsgResult, error
 
 // TestWsLatency test all clusters' websocket pub sub latency
 func TestWsLatency(config WsConfig) {
-	token := AssignString(config.Token, GetConfig().Token)
-	expectedLatency := TimeDuration(config.LatencyBudgetMs, 2*latencyBudget, time.Millisecond)
+	token := util.AssignString(config.Token, GetConfig().Token)
+	expectedLatency := util.TimeDuration(config.LatencyBudgetMs, 2*latencyBudget, time.Millisecond)
 
-	stdVerdict := GetStdBucket(config.Cluster)
+	stdVerdict := util.GetStdBucket(config.Cluster)
 
 	result, err := WsLatencyTest(config.ProducerURL, config.ConsumerURL, token)
 	if err != nil {
@@ -205,7 +206,7 @@ func WebSocketTopicLatencyTestThread() {
 		log.Println(cfg.Name)
 		cfg.reconcileConfig()
 		go func(t WsConfig) {
-			ticker := time.NewTicker(TimeDuration(t.IntervalSeconds, 60, time.Second))
+			ticker := time.NewTicker(util.TimeDuration(t.IntervalSeconds, 60, time.Second))
 			TestWsLatency(t)
 			for {
 				select {


### PR DESCRIPTION
This PR supports in-cluster Kubernetes cluster monitoring. RBAC is configured by  pulsar-monitor's rbac configuration under pulsar-helm-chart repo.

Implemented partition topic message latency measurement. The producer will send multiple messages with keys to a partition partition topic. Multiple subscriptions are created for each partitioned topic to receive and validate messages. It will also time the latency and report any errors.

Another fix is to collect all latency sample for the standard deviation verdict. It collects the samples that fails the hard limit which was excluded earlier.