### PR TITLE
verbosity option for slack alert

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -60,7 +60,10 @@ jobs:
         run: |
           cd src
           go vet ./...
-
+      - name: Go test
+        run: |
+          cd src
+          go test ./...
   docker:
     name: docker
     runs-on: ubuntu-latest 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 
 all: push
 
-TAG ?= 1.2.6
+TAG ?= 1.2.7
 PREFIX ?= kesque/pulsar-monitor
 
 container:

--- a/config/runtime-template.json
+++ b/config/runtime-template.json
@@ -1,0 +1,57 @@
+{
+    "prometheusConfig": {
+        "port": ":8083",
+        "exposeMetrics": true
+    },
+    "slackConfig": {
+        "alertUrl": ""
+    },
+
+    "name": "localhost",
+    "opsGenieConfig": {
+        "intervalSeconds": 180,
+        "heartbeatKey": "",
+        "alertKey": ""
+    },
+    "pulsarOpsConfig": {
+        "intervalSeconds": 120,
+        "masterToken": "eyJhbGciOiJSUzI",
+        "clusters": [
+            {
+                "name": "localhost",
+                "alertPolicy": {
+                    "Ceiling": 10,
+                    "MovingWindowSeconds": 30,
+                    "CeilingInMovingWindow": 10
+                }
+            }
+        ]
+    },
+    "pulsarFunctionsConfig": {},
+    "pulsarPerfConfig": {
+        "intervalSeconds": 120,
+        "token": "",
+        "topicCfgs": [
+            {
+                "latencyBudgetMs": 360,
+                "pulsarUrl": "pulsar+ssl://localhost:6651",
+                "topicName": "persistent://public/default/reserved-cluster-monitoring",
+                "alertPolicy": {
+                    "Ceiling": 30,
+                    "MovingWindowSeconds": 600,
+                    "CeilingInMovingWindow": 5
+                }
+            },
+            {
+                "latencyBudgetMs": 2400,
+                "pulsarUrl": "pulsar+ssl://host:6651",
+                "topicName": "persistent://public/default/reserved-cluster-monitoring",
+                "alertPolicy": {
+                    "Ceiling": 3,
+                    "MovingWindowSeconds": 600,
+                    "CeilingInMovingWindow": 5
+                }
+            }
+        ]
+    }
+}

--- a/go.sum
+++ b/go.sum
@@ -248,6 +248,7 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=
 github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-retryablehttp v0.6.4 h1:BbgctKO892xEyOXnGiaAwIoSq1QZ/SS4AhjoAh9DnfY=
 github.com/hashicorp/go-retryablehttp v0.6.4/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=

--- a/src/broker-monitor.go
+++ b/src/broker-monitor.go
@@ -19,11 +19,11 @@ func EvaluateBrokers(prefixURL, token string) error {
 
 	if failedBrokers > 0 {
 		errMsg := fmt.Sprintf("cluster %s has %d unhealthy brokers, error message %v", name, failedBrokers, err)
-		Alert(errMsg)
+		VerboseAlert(name+"-broker", errMsg, 3*time.Minute)
 		ReportIncident(name, name, "brokers are unhealthy reported by pulsar-monitor", errMsg, &cfg.AlertPolicy)
 	} else if err != nil {
 		errMsg := fmt.Sprintf("cluster %s Pulsar brokers test failed, error message %v", name, err)
-		Alert(errMsg)
+		VerboseAlert(name+"-broker", errMsg, 3*time.Minute)
 	} else {
 		ClearIncident(name)
 	}

--- a/src/cluster-monitor.go
+++ b/src/cluster-monitor.go
@@ -9,11 +9,6 @@ import (
 	"github.com/kafkaesque-io/pulsar-monitor/src/k8s"
 )
 
-// K8s pulsar cluster monitor
-var (
-	lastAlertMessageTime time.Time = time.Now()
-)
-
 const clusterMonInterval = 10 * time.Second
 
 // ClusterHealth a cluster health struct
@@ -61,12 +56,8 @@ func EvaluateClusterHealth(client *k8s.Client) error {
 	if status.Status != k8s.OK {
 		errMsg := fmt.Sprintf("cluster %s, k8s pulsar cluster status is unhealthy, error message %s", cluster, desc)
 		if status.Status == k8s.TotalDown {
-			Alert(errMsg)
+			VerboseAlert(cluster, errMsg, 3*time.Minute)
 			ReportIncident(cluster, cluster, "kubernete cluster is down, reported by pulsar-monitor", errMsg, &cfg.AlertPolicy)
-		} else if time.Since(lastAlertMessageTime) > 1*time.Minute {
-			// tune down the alert verbosity at every minute
-			Alert(errMsg)
-			lastAlertMessageTime = time.Now()
 		}
 	} else {
 		ClearIncident(cluster)

--- a/src/config.go
+++ b/src/config.go
@@ -22,6 +22,7 @@ type PrometheusCfg struct {
 // SlackCfg is slack configuration
 type SlackCfg struct {
 	AlertURL string `json:"alertUrl"`
+	Verbose  bool   `json:"verbose"`
 }
 
 // OpsGenieCfg is opsGenie configuration

--- a/src/heartbeat.go
+++ b/src/heartbeat.go
@@ -32,6 +32,8 @@ func UptimeHeartBeat() {
 // HeartBeatToOpsGenie send heart beat to ops genie
 func HeartBeatToOpsGenie(genieURL, genieKey string) error {
 
+	name := GetConfig().Name
+
 	client := retryablehttp.NewClient()
 	client.HTTPClient.Timeout = time.Duration(5) * time.Second
 	client.RetryWaitMin = 4 * time.Second
@@ -51,13 +53,13 @@ func HeartBeatToOpsGenie(genieURL, genieKey string) error {
 	}
 	if err != nil {
 		log.Println(err)
-		Alert(fmt.Sprintf("Opsgenie returns error %v", err))
+		Alert(fmt.Sprintf("from %s Opsgenie returns error %v", name, err))
 		return err
 	}
 
 	log.Print("opsgenie status code ", resp.StatusCode)
 	if resp.StatusCode > 300 {
-		msg := fmt.Sprintf("Opsgenie returns incorrect status code %d", resp.StatusCode)
+		msg := fmt.Sprintf("from %s Opsgenie returns incorrect status code %d", name, resp.StatusCode)
 		Alert(msg)
 		return errors.New(msg)
 	}

--- a/src/incident.go
+++ b/src/incident.go
@@ -198,7 +198,7 @@ func CreateIncident(component, alias, msg, desc, priority string) {
 	genieKey := GetConfig().OpsGenieConfig.AlertKey
 	err := CreateOpsGenieAlert(NewIncident(component, alias, msg, desc, priority), genieKey)
 	if err != nil {
-		Alert(fmt.Sprintf("Opsgenie report incident error %v", err))
+		Alert(fmt.Sprintf("from %s Opsgenie report incident error %v", component, err))
 	}
 }
 
@@ -226,7 +226,7 @@ func RemoveIncident(component string) {
 		genieKey := GetConfig().OpsGenieConfig.AlertKey
 		err := CloseOpsGenieAlert(component, record.alertID, genieKey)
 		if err != nil {
-			Alert(fmt.Sprintf("Opsgenie remove incident error %v", err))
+			Alert(fmt.Sprintf("from %s Opsgenie remove incident error %v", component, err))
 		}
 	}
 }

--- a/src/incident_test.go
+++ b/src/incident_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestUnmarshConfigFile(t *testing.T) {
 	ReadConfigFile("../config/runtime-template.json")
-	assert(t, ":8081" == GetConfig().PrometheusConfig.Port, "load json config")
+	assert(t, ":8083" == GetConfig().PrometheusConfig.Port, "load json config")
 	ReadConfigFile("../config/runtime-template.yml")
 	assert(t, ":8080" == GetConfig().PrometheusConfig.Port, "load yaml config")
 

--- a/src/pulsar-admin.go
+++ b/src/pulsar-admin.go
@@ -68,13 +68,13 @@ func PulsarTenants() {
 		tenantSize, err := PulsarAdminTenant(queryURL, token)
 		if err != nil {
 			errMsg := fmt.Sprintf("tenant-test failed on cluster %s error: %v", queryURL, err)
-			Alert(errMsg)
+			VerboseAlert(clusterName+"-pulsar-admin", errMsg, 3*time.Minute)
 			ReportIncident(cluster.Name, clusterName, "persisted cluster tenants test failure", errMsg, &cluster.AlertPolicy)
 		} else {
 			PromGaugeInt(TenantsGaugeOpt(), cluster.Name, tenantSize)
 			ClearIncident(cluster.Name)
 			if tenantSize == 0 {
-				Alert(fmt.Sprintf("%s has incorrect number of tenants 0", cluster.Name))
+				VerboseAlert(clusterName+"-pulsar-admin", fmt.Sprintf("%s has incorrect number of tenants 0", cluster.Name), 3*time.Minute)
 			} else {
 				log.Printf("cluster %s has %d numbers of tenants", clusterName, tenantSize)
 			}

--- a/src/util/datastruct_test.go
+++ b/src/util/datastruct_test.go
@@ -1,0 +1,78 @@
+package util
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestSyncMap(t *testing.T) {
+	syncMap := NewSycMap()
+
+	if !syncMap.IsEmpty() {
+		t.FailNow()
+	}
+
+	syncMap.Put("test", "value0")
+	if syncMap.Size() != 1 {
+		t.FailNow()
+	}
+	syncMap.Put("test", "value1")
+	syncMap.Put("test2", "value2")
+	syncMap.Put("test3", "value3")
+
+	if syncMap.Get("test3") != "value3" {
+		t.Fatal("expect key test3 value ")
+	}
+	if syncMap.Get("test") != "value1" {
+		t.Fatal("expect key test value is value1")
+	}
+	if syncMap.Get("test4") != nil {
+		t.Fatal("expect no test4 key")
+	}
+
+	type finish struct{}
+	it := 1000
+	finishSig := make(chan *finish, it)
+	go func() {
+		for k := range [1000]int{1} {
+			go func(i int) {
+				syncMap.Put("test"+strconv.Itoa(i), "value")
+				finishSig <- &finish{}
+			}(k)
+		}
+	}()
+	if syncMap.Size() > it {
+		t.Fatal("finish too quick")
+	}
+
+	ticker := time.NewTicker(4 * time.Second)
+	finalCount := 0
+	for finalCount != it {
+		select {
+		case <-finishSig:
+			finalCount++
+			fmt.Printf("%d\n", finalCount)
+		case <-ticker.C:
+			t.Fatal("time out wait for put() loop to complete")
+		}
+	}
+	if syncMap.Size() != it+1 {
+		t.Fatalf("expect size to be %d", it+1)
+	}
+
+	if syncMap.Get("test345") != "value" {
+		t.Fatal("expect key test3 value ")
+	}
+	if syncMap.Get("test") != "value1" {
+		t.Fatal("expect key test value is value1")
+	}
+
+	if syncMap.Replace("test", "value2") != "value1" {
+		t.Fatal("Replace expect key test previous value is value1")
+	}
+	if syncMap.Get("test") != "value2" {
+		t.Fatal("Replace expect key test new value is value2")
+	}
+}

--- a/src/util/sycmap.go
+++ b/src/util/sycmap.go
@@ -1,0 +1,79 @@
+package util
+
+import "sync"
+
+// SyncMap is a generic map data structure protected with syc.RWMutex
+type SyncMap struct {
+	sync.RWMutex
+	data map[interface{}]interface{}
+}
+
+// NewSycMap creates a new SyncMap
+func NewSycMap() *SyncMap {
+	return &SyncMap{
+		data: make(map[interface{}]interface{}),
+	}
+}
+
+// Put associates the specified value with the specified key in this map
+func (sm *SyncMap) Put(key interface{}, value interface{}) interface{} {
+	sm.Lock()
+	defer sm.Unlock()
+
+	sm.data[key] = value
+	return sm.data[key]
+}
+
+// Replace puts a key and value pair and returns a previous value if exists,
+func (sm *SyncMap) Replace(key interface{}, value interface{}) interface{} {
+	sm.Lock()
+	defer sm.Unlock()
+	previous := sm.data[key]
+	sm.data[key] = value
+	return previous
+}
+
+// Get returns the value to which the specified key is mapped, or nil if this map contains no mapping for the key.
+func (sm *SyncMap) Get(key interface{}) interface{} {
+	sm.RLock()
+	defer sm.RUnlock()
+
+	return sm.data[key]
+}
+
+// GetOrDefault returns the value to which the specified key is mapped, or nil if this map contains no mapping for the key.
+func (sm *SyncMap) GetOrDefault(key interface{}, defaultValue interface{}) interface{} {
+	sm.RLock()
+	defer sm.RUnlock()
+
+	if value := sm.data[key]; value != nil {
+		return value
+	}
+	return defaultValue
+}
+
+// Size returns the size of the map
+func (sm *SyncMap) Size() int {
+	sm.RLock()
+	defer sm.RUnlock()
+	return len(sm.data)
+}
+
+// IsEmpty returns whether the map is empty
+func (sm *SyncMap) IsEmpty() bool {
+	if sm.Size() == 0 {
+		return true
+	}
+	return false
+}
+
+// Remove removes the specified key and associsated value
+func (sm *SyncMap) Remove(key interface{}) {
+	sm.Lock()
+	defer sm.Unlock()
+
+	delete(sm.data, key)
+}
+
+// TODO: add these functions
+// Clear()

--- a/src/website-monitor.go
+++ b/src/website-monitor.go
@@ -70,8 +70,8 @@ func mon(site SiteCfg) {
 	err := monitorSite(site)
 	if err != nil {
 		errMsg := fmt.Sprintf("site monitoring %s error: %v", site.URL, err)
-		title := fmt.Sprintf("persisted kafkaesque.io %s endpoint failure", site.Name)
-		Alert(errMsg)
+		title := fmt.Sprintf("persisted %s endpoint failure", site.Name)
+		VerboseAlert(site.Name+"-site-monitor", errMsg, 3*time.Minute)
 		ReportIncident(site.Name, site.Name, title, errMsg, &site.AlertPolicy)
 	} else {
 		ClearIncident(site.Name)

--- a/src/websocket.go
+++ b/src/websocket.go
@@ -175,17 +175,17 @@ func TestWsLatency(config WsConfig) {
 	result, err := WsLatencyTest(config.ProducerURL, config.ConsumerURL, token)
 	if err != nil {
 		errMsg := fmt.Sprintf("cluster %s, %s websocket latency test Pulsar error: %v", config.Cluster, config.Name, err)
-		Alert(errMsg)
+		VerboseAlert(config.Name+"-websocket-err", errMsg, 3*time.Minute)
 	} else if result.Latency > expectedLatency {
 		stdVerdict.Add(float64(result.Latency.Milliseconds()))
 		errMsg := fmt.Sprintf("cluster %s, %s websocket test message latency %v over the budget %v",
 			config.Cluster, config.Name, result.Latency, expectedLatency)
-		Alert(errMsg)
+		VerboseAlert(config.Name+"-websocket-latency", errMsg, 3*time.Minute)
 		ReportIncident(config.Name, config.Cluster, "websocket persisted latency test failure", errMsg, &config.AlertPolicy)
 	} else if stddev, mean, within3Sigma := stdVerdict.Push(float64(result.Latency.Milliseconds())); !within3Sigma {
 		errMsg := fmt.Sprintf("cluster %s, websocket test message latency %v over three standard deviation %v ms and mean is %v ms",
 			config.Cluster, result.Latency, stddev, mean)
-		Alert(errMsg)
+		VerboseAlert(config.Name+"-websocket-stddev", errMsg, 10*time.Minute)
 		ReportIncident(config.Name, config.Cluster, "websocket persisted latency test failure", errMsg, &config.AlertPolicy)
 
 	} else {


### PR DESCRIPTION
Here are configurations to reduce slack alert verbosity
- A boolean verbose option to enable/disable verbose Slack alert
- Each alert is tracked against a silence window. Within such window, the alert to Slack will be suppressed.
- The silence window can be defined by each component.