### PR TITLE
option to read Pulsar token from a file

### DIFF
--- a/config/runtime-single-cluster-standalone.yml
+++ b/config/runtime-single-cluster-standalone.yml
@@ -1,5 +1,6 @@
 ---
 name: remote-monitor-example
+tokenFilePath:
 token: eyJhbGciOiJSUzI1NiJ...[kesque pulsar JWT]
 slackConfig:
   alertUrl: https://hooks.slack.com/services/[slack alert app]


### PR DESCRIPTION
- Read a Pulsar JWT from a file. This will integrate with Pulsar Helm chart to reuse the jwt file mounted by the secret.
- If both token file path and token attribute present in the config file, the token from the file will take precedence.
- Pulsar monitor will continue even if it fails to read the token file. However, this can be changed.