### PR TITLE
code refactor and alerts based on multiple targets correlation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 
 all: push
 
-TAG ?= 1.2.7
+TAG ?= 1.2.8
 PREFIX ?= kesque/pulsar-monitor
 
 container:

--- a/src/cfg/analytics.go
+++ b/src/cfg/analytics.go
@@ -1,4 +1,4 @@
-package main
+package cfg
 
 import (
 	"bytes"

--- a/src/cfg/broker-monitor.go
+++ b/src/cfg/broker-monitor.go
@@ -1,4 +1,4 @@
-package main
+package cfg
 
 import (
 	"fmt"
@@ -13,14 +13,14 @@ import (
 func EvaluateBrokers(prefixURL, token string) error {
 	name := GetConfig().Name + "-brokers" // again this is for in-cluster monitoring only
 
-	cfg := GetConfig().BrokersConfig
+	brokerCfg := GetConfig().BrokersConfig
 	clusterName := util.AssignString(GetConfig().ClusterName, GetConfig().Name)
 	failedBrokers, err := brokers.TestBrokers(prefixURL, clusterName, token)
 
 	if failedBrokers > 0 {
 		errMsg := fmt.Sprintf("cluster %s has %d unhealthy brokers, error message %v", name, failedBrokers, err)
 		VerboseAlert(name+"-broker", errMsg, 3*time.Minute)
-		ReportIncident(name, name, "brokers are unhealthy reported by pulsar-monitor", errMsg, &cfg.AlertPolicy)
+		ReportIncident(name, name, "brokers are unhealthy reported by pulsar-monitor", errMsg, &brokerCfg.AlertPolicy)
 	} else if err != nil {
 		errMsg := fmt.Sprintf("cluster %s Pulsar brokers test failed, error message %v", name, err)
 		VerboseAlert(name+"-broker", errMsg, 3*time.Minute)

--- a/src/cfg/cluster-monitor.go
+++ b/src/cfg/cluster-monitor.go
@@ -1,4 +1,4 @@
-package main
+package cfg
 
 import (
 	"fmt"
@@ -18,6 +18,8 @@ type ClusterHealth struct {
 	MissingBrokers int
 }
 
+var clusterHealth = ClusterHealth{}
+
 // Get gets the cluster health status
 func (h *ClusterHealth) Get() (k8s.ClusterStatusCode, int) {
 	h.RLock()
@@ -35,7 +37,7 @@ func (h *ClusterHealth) Set(status k8s.ClusterStatusCode, offlineBrokers int) {
 
 // EvaluateClusterHealth evaluates and reports the k8s cluster health
 func EvaluateClusterHealth(client *k8s.Client) error {
-	cfg := GetConfig().K8sConfig
+	k8sCfg := GetConfig().K8sConfig
 	cluster := GetConfig().Name + "-in-cluster"
 	// again this is for in-cluster monitoring only
 
@@ -57,7 +59,7 @@ func EvaluateClusterHealth(client *k8s.Client) error {
 		errMsg := fmt.Sprintf("cluster %s, k8s pulsar cluster status is unhealthy, error message %s", cluster, desc)
 		if status.Status == k8s.TotalDown {
 			VerboseAlert(cluster, errMsg, 3*time.Minute)
-			ReportIncident(cluster, cluster, "kubernete cluster is down, reported by pulsar-monitor", errMsg, &cfg.AlertPolicy)
+			ReportIncident(cluster, cluster, "kubernete cluster is down, reported by pulsar-monitor", errMsg, &k8sCfg.AlertPolicy)
 		}
 	} else {
 		ClearIncident(cluster)
@@ -68,8 +70,8 @@ func EvaluateClusterHealth(client *k8s.Client) error {
 
 // MonitorK8sPulsarCluster start K8sPulsarClusterMonitor thread
 func MonitorK8sPulsarCluster() error {
-	cfg := GetConfig().K8sConfig
-	if !cfg.Enabled {
+	k8sCfg := GetConfig().K8sConfig
+	if !k8sCfg.Enabled {
 		return nil
 	}
 

--- a/src/cfg/config.go
+++ b/src/cfg/config.go
@@ -1,4 +1,4 @@
-package main
+package cfg
 
 import (
 	"bytes"
@@ -154,7 +154,7 @@ type Configuration struct {
 
 // AlertPolicyCfg is a set of criteria to evaluation triggers for incident alert
 type AlertPolicyCfg struct {
-	// first evalation for a single count
+	// first evaluation to count continuous failure
 	Ceiling int `json:"ceiling"`
 	// Second evaluation for moving window
 	MovingWindowSeconds   int `json:"movingWindowSeconds"`

--- a/src/cfg/heartbeat.go
+++ b/src/cfg/heartbeat.go
@@ -1,4 +1,4 @@
-package main
+package cfg
 
 import (
 	"errors"

--- a/src/cfg/incident_test.go
+++ b/src/cfg/incident_test.go
@@ -1,4 +1,4 @@
-package main
+package cfg
 
 import (
 	"fmt"
@@ -13,9 +13,9 @@ import (
 )
 
 func TestUnmarshConfigFile(t *testing.T) {
-	ReadConfigFile("../config/runtime-template.json")
+	ReadConfigFile("../../config/runtime-template.json")
 	assert(t, ":8083" == GetConfig().PrometheusConfig.Port, "load json config")
-	ReadConfigFile("../config/runtime-template.yml")
+	ReadConfigFile("../../config/runtime-template.yml")
 	assert(t, ":8080" == GetConfig().PrometheusConfig.Port, "load yaml config")
 
 }

--- a/src/cfg/metrics.go
+++ b/src/cfg/metrics.go
@@ -1,4 +1,4 @@
-package main
+package cfg
 
 import (
 	"bufio"
@@ -209,7 +209,7 @@ func GetOfflinePodsCounter(subsystem string) prometheus.GaugeOpts {
 
 // scrapeLocal scrapes the local metrics
 func scrapeLocal() ([]byte, error) {
-	url := "http://localhost" + Config.PrometheusConfig.Port + "/metrics"
+	url := "http://localhost" + GetConfig().PrometheusConfig.Port + "/metrics"
 	newRequest, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		log.Printf("make http request to scrape self's prometheus %s error %v", url, err)
@@ -281,19 +281,18 @@ func PushToPrometheusProxy(proxyURL, authKey string) error {
 		log.Printf("push to prometheus proxy %s error status code %v", proxyURL, resp.StatusCode)
 		return fmt.Errorf("push to prometheus proxy %s error status code %v", proxyURL, resp.StatusCode)
 	}
-	// log.Println("successfully pushed to prometheus proxy")
 
 	return nil
 }
 
 // PushToPrometheusProxyThread is the daemon thread that scrape and pushes metrics to prometheus proxy
 func PushToPrometheusProxyThread() {
-	cfg := GetConfig().PrometheusConfig
-	if cfg.PrometheusProxyURL == "" && cfg.ExposeMetrics {
+	promCfg := GetConfig().PrometheusConfig
+	if promCfg.PrometheusProxyURL == "" && promCfg.ExposeMetrics {
 		log.Println("This process is not configured to push metrics to prometheus proxy.")
 		return
 	}
-	proxyInstanceURL := cfg.PrometheusProxyURL + "/" + GetConfig().Name
+	proxyInstanceURL := promCfg.PrometheusProxyURL + "/" + GetConfig().Name
 
 	log.Printf("push to prometheus proxy url %s", GetConfig().PrometheusConfig.PrometheusProxyURL)
 	go func(url, apikey string) {
@@ -305,7 +304,7 @@ func PushToPrometheusProxyThread() {
 				PushToPrometheusProxy(url, apikey)
 			}
 		}
-	}(proxyInstanceURL, cfg.PrometheusProxyAPIKey)
+	}(proxyInstanceURL, promCfg.PrometheusProxyAPIKey)
 
 }
 

--- a/src/cfg/payload.go
+++ b/src/cfg/payload.go
@@ -1,4 +1,4 @@
-package main
+package cfg
 
 import (
 	"fmt"

--- a/src/cfg/pulsar-admin.go
+++ b/src/cfg/pulsar-admin.go
@@ -1,4 +1,4 @@
-package main
+package cfg
 
 import (
 	"encoding/json"

--- a/src/cfg/pulsar-latency.go
+++ b/src/cfg/pulsar-latency.go
@@ -1,4 +1,4 @@
-package main
+package cfg
 
 import (
 	"context"
@@ -291,7 +291,9 @@ func testTopicLatency(clusterName, token string, topicCfg TopicCfg) {
 		AnalyticsLatencyReport(clusterName, testName, "", int(result.Latency.Milliseconds()), true, true)
 		ClearIncident(clusterName)
 	}
-	PromLatencySum(GetGaugeType(topicCfg.Name), clusterName, result.Latency)
+	if result.Latency < failedLatency {
+		PromLatencySum(GetGaugeType(topicCfg.Name), clusterName, result.Latency)
+	}
 }
 
 func expectedMessage(payload, expected string) string {

--- a/src/cfg/slack.go
+++ b/src/cfg/slack.go
@@ -1,4 +1,4 @@
-package main
+package cfg
 
 import (
 	"bytes"

--- a/src/cfg/website-monitor.go
+++ b/src/cfg/website-monitor.go
@@ -1,4 +1,4 @@
-package main
+package cfg
 
 import (
 	"fmt"

--- a/src/cfg/websocket.go
+++ b/src/cfg/websocket.go
@@ -1,4 +1,4 @@
-package main
+package cfg
 
 import (
 	"encoding/base64"


### PR DESCRIPTION
- Code refactoring that organizes code to package folders
- Add a new way to create incident alert that can correlate to multiple components failure close to each other
- Remove of prometheus latency report when time out and error occurs that has created inaccurate latency numbers and mess up with the grafana chart 